### PR TITLE
Adds ability to use custom fields in the profile module.

### DIFF
--- a/classes/profile_actions.php
+++ b/classes/profile_actions.php
@@ -83,6 +83,8 @@ class Profile_Actions extends Cms_ActionScope {
 			
 			$billing_info = Shop_CheckoutData::get_billing_info();
 			
+			$this->customer->set_api_fields(Shop_CheckoutData::get_custom_fields());
+			
 			$this->customer->company = $billing_info->company;
 			$this->customer->billing_country_id = $billing_info->country;
 			$this->customer->billing_state_id = $billing_info->state;
@@ -117,6 +119,9 @@ class Profile_Actions extends Cms_ActionScope {
 			
 			Shop_CheckoutData::set_shipping_info();
 			Shop_CheckoutData::get_shipping_info()->save_to_customer($this->customer);
+			
+			$this->customer->set_api_fields(Shop_CheckoutData::get_custom_fields());
+			
 			$this->customer->password = null;
 			$this->customer->save();
 			


### PR DESCRIPTION
This change uses the `set_api_fields` method to add form fields that were posted in the form using the `Shop_CheckoutData::get_custom_fields()` format to the customer model before saving.

You will be able to use fields by the name `custom_fields['x_column_name']` in your form along side the `shipping[]` or `billing[]` ones and they will save to the customer model as you might expect.